### PR TITLE
Add code coverage and badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,24 @@ jobs:
           allow-prereleases: true
       - run: pip install -r requirements-dev.txt
       - run: pip install -e .
-      - run: pytest
+      - name: Run tests with coverage
+        if: matrix.python-version == '3.14'
+        run: |
+          pytest --cov=msqlite --cov-report=term | tee coverage.txt
+          COVERAGE=$(grep "^TOTAL" coverage.txt | awk '{print $NF}' | tr -d '%')
+          echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+      - name: Run tests
+        if: matrix.python-version != '3.14'
+        run: pytest
+      - name: Update coverage badge
+        if: matrix.python-version == '3.14' && github.ref == 'refs/heads/main'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 6d52e73f56390c801b04efe41af174d4
+          filename: coverage.json
+          label: coverage
+          message: ${{ env.COVERAGE }}%
+          valColorRange: ${{ env.COVERAGE }}
+          minColorRange: 50
+          maxColorRange: 100

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Tests](https://github.com/jamesabel/msqlite/actions/workflows/tests.yml/badge.svg)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jamesabel/6d52e73f56390c801b04efe41af174d4/raw/coverage.json)
+
 # msqlite
 
 Multi-threaded/multi-process support on top of SQLite. The intent is to ensure a SQL statement


### PR DESCRIPTION
## Summary
- Add code coverage reporting (pytest-cov) to the CI test workflow on Python 3.14
- Add Tests and Coverage badges to README
- Coverage badge auto-updates via gist on pushes to main

## Setup required
Add a repo secret `GIST_TOKEN` with a PAT that has `gist` scope.

## Test plan
- [x] 93% coverage confirmed locally
- [ ] CI runs and coverage step passes
- [ ] Badge renders in README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)