### PR TITLE
Fix coverage badge gist ID

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
-          gistID: 6d52e73f56390c801b04efe41af174d4
+          gistID: 073de6201c5dc8c7d26d464af31c2a4b
           filename: coverage.json
           label: coverage
           message: ${{ env.COVERAGE }}%

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Tests](https://github.com/jamesabel/msqlite/actions/workflows/tests.yml/badge.svg)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jamesabel/6d52e73f56390c801b04efe41af174d4/raw/coverage.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jamesabel/073de6201c5dc8c7d26d464af31c2a4b/raw/coverage.json)
 
 # msqlite
 


### PR DESCRIPTION
## Summary
- Replace private gist with public gist so shields.io can read the coverage badge
- Previous run failed with 401 because the secret wasn't set yet; now fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)