### PR TITLE
Bump to v0.7.1: quieter __exit__ logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "msqlite"
-version = "0.7.0"
+version = "0.7.1"
 description = "Execute simple SQLite statements that are multithreaded/multiprocess safe"
 readme = "README.md"
 authors = [{ name = "James Abel", email = "j@abel.co" }]

--- a/src/msqlite/msqlite.py
+++ b/src/msqlite/msqlite.py
@@ -137,8 +137,11 @@ class MSQLite:
                 self.conn.rollback()
             self.conn.close()
             self.conn = None
-        log.info(f"{self.max_execution_time=}")
-        log.info(f"{self.retry_count=}")
+        log.debug(f"{self.max_execution_time=}")
+        if self.retry_count > 0:
+            log.info(f"{self.retry_count=}")
+        else:
+            log.debug(f"{self.retry_count=}")
 
     def create_table(self):
         """


### PR DESCRIPTION
## Summary
- Bump version 0.7.0 → 0.7.1
- Demote `max_execution_time` log in `__exit__` from info to debug
- Only log `retry_count` at info when non-zero; otherwise debug

## Test plan
- [ ] `pytest` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)